### PR TITLE
feat: Show open windows preview on dock item hover

### DIFF
--- a/src/main/java/com/github/arthurdeka/cedromoderndock/controller/DockController.java
+++ b/src/main/java/com/github/arthurdeka/cedromoderndock/controller/DockController.java
@@ -9,6 +9,7 @@ import com.github.arthurdeka.cedromoderndock.util.SaveAndLoadDockSettings;
 import com.github.arthurdeka.cedromoderndock.util.WindowsIconHandler;
 import com.github.arthurdeka.cedromoderndock.view.WindowPreviewPopup;
 import javafx.animation.PauseTransition;
+import javafx.animation.ScaleTransition;
 import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
@@ -165,6 +166,13 @@ public class DockController {
             button.setOnMouseEntered(e -> {
                 isHovering[0] = true;
                 hideDelay.stop();
+
+                // Scale Up immediately on hover
+                ScaleTransition scaleUp = new ScaleTransition(Duration.millis(200), button);
+                scaleUp.setToX(1.3);
+                scaleUp.setToY(1.3);
+                scaleUp.play();
+
                 hoverDelay.setOnFinished(event -> {
                     new Thread(() -> {
                         List<WindowInfo> windows = NativeWindowUtils.getAppWindows(item.getPath());
@@ -185,6 +193,12 @@ public class DockController {
                                         if (!isHovering[0] && activePopup[0] != null) {
                                             activePopup[0].hide();
                                             activePopup[0] = null;
+
+                                            // Reset scale when popup actually closes from popup exit
+                                            ScaleTransition scaleDown = new ScaleTransition(Duration.millis(200), button);
+                                            scaleDown.setToX(1.0);
+                                            scaleDown.setToY(1.0);
+                                            scaleDown.play();
                                         }
                                     });
                                     hideDelay.playFromStart();
@@ -206,14 +220,20 @@ public class DockController {
 
             button.setOnMouseExited(e -> {
                 // Only mark not hovering if we haven't moved to the popup
-                // But JavaFX events are tricky. We assume we left. The hide delay handles the grace period.
                 isHovering[0] = false;
                 hoverDelay.stop();
                 hideDelay.setOnFinished(event -> {
                     // Check again inside the delay if we re-entered either the button or the popup
-                    if (!isHovering[0] && activePopup[0] != null) {
-                        activePopup[0].hide();
-                        activePopup[0] = null;
+                    if (!isHovering[0]) {
+                        if (activePopup[0] != null) {
+                            activePopup[0].hide();
+                            activePopup[0] = null;
+                        }
+                        // Only scale down if we truly left and popup is closed
+                        ScaleTransition scaleDown = new ScaleTransition(Duration.millis(200), button);
+                        scaleDown.setToX(1.0);
+                        scaleDown.setToY(1.0);
+                        scaleDown.play();
                     }
                 });
                 hideDelay.playFromStart();

--- a/src/main/java/com/github/arthurdeka/cedromoderndock/controller/DockController.java
+++ b/src/main/java/com/github/arthurdeka/cedromoderndock/controller/DockController.java
@@ -175,10 +175,14 @@ public class DockController {
                                 activePopup[0] = new WindowPreviewPopup(windows, imageView.getImage());
 
                                 // Keep popup open if mouse enters it
-                                activePopup[0].getContent().get(0).setOnMouseEntered(me -> hideDelay.stop());
+                                activePopup[0].getContent().get(0).setOnMouseEntered(me -> {
+                                    isHovering[0] = true; // Consider hovering popup as hovering context
+                                    hideDelay.stop();
+                                });
                                 activePopup[0].getContent().get(0).setOnMouseExited(me -> {
+                                    isHovering[0] = false;
                                     hideDelay.setOnFinished(ev -> {
-                                        if (activePopup[0] != null) {
+                                        if (!isHovering[0] && activePopup[0] != null) {
                                             activePopup[0].hide();
                                             activePopup[0] = null;
                                         }
@@ -201,10 +205,13 @@ public class DockController {
             });
 
             button.setOnMouseExited(e -> {
+                // Only mark not hovering if we haven't moved to the popup
+                // But JavaFX events are tricky. We assume we left. The hide delay handles the grace period.
                 isHovering[0] = false;
                 hoverDelay.stop();
                 hideDelay.setOnFinished(event -> {
-                    if (activePopup[0] != null) {
+                    // Check again inside the delay if we re-entered either the button or the popup
+                    if (!isHovering[0] && activePopup[0] != null) {
                         activePopup[0].hide();
                         activePopup[0] = null;
                     }

--- a/src/main/java/com/github/arthurdeka/cedromoderndock/util/NativeWindowUtils.java
+++ b/src/main/java/com/github/arthurdeka/cedromoderndock/util/NativeWindowUtils.java
@@ -1,0 +1,83 @@
+package com.github.arthurdeka.cedromoderndock.util;
+
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.platform.win32.User32;
+import com.sun.jna.platform.win32.WinDef.HWND;
+import com.sun.jna.platform.win32.WinUser;
+import com.sun.jna.platform.win32.WinUser.WNDENUMPROC;
+import com.sun.jna.ptr.IntByReference;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class NativeWindowUtils {
+
+    public record WindowInfo(HWND hwnd, String title) {}
+
+    public static List<WindowInfo> getAppWindows(String targetExePath) {
+        List<WindowInfo> result = new ArrayList<>();
+
+        // Safety check for non-Windows environments (development)
+        if (!System.getProperty("os.name").toLowerCase().contains("win")) {
+            return result;
+        }
+
+        if (targetExePath == null || targetExePath.isEmpty()) {
+            return result;
+        }
+
+        final User32 user32 = User32.INSTANCE;
+        user32.EnumWindows(new WNDENUMPROC() {
+            @Override
+            public boolean callback(HWND hWnd, Pointer arg1) {
+                if (user32.IsWindowVisible(hWnd)) {
+                    char[] buffer = new char[1024];
+                    user32.GetWindowText(hWnd, buffer, 1024);
+                    String title = Native.toString(buffer);
+
+                    if (title.isEmpty()) {
+                        return true;
+                    }
+
+                    IntByReference processId = new IntByReference();
+                    user32.GetWindowThreadProcessId(hWnd, processId);
+
+                    Optional<ProcessHandle> handle = ProcessHandle.of(processId.getValue());
+                    if (handle.isPresent()) {
+                         ProcessHandle.Info info = handle.get().info();
+                         if (info.command().isPresent()) {
+                             String command = info.command().get();
+                             if (pathsMatch(command, targetExePath)) {
+                                 result.add(new WindowInfo(hWnd, title));
+                             }
+                         }
+                    }
+                }
+                return true;
+            }
+        }, null);
+        return result;
+    }
+
+    private static boolean pathsMatch(String path1, String path2) {
+        if (path1 == null || path2 == null) return false;
+        // Normalize separators
+        String p1 = path1.replace("\\", "/");
+        String p2 = path2.replace("\\", "/");
+        return p1.equalsIgnoreCase(p2);
+    }
+
+    public static void activateWindow(HWND hwnd) {
+        // Safety check for non-Windows environments
+        if (!System.getProperty("os.name").toLowerCase().contains("win")) {
+            return;
+        }
+
+        User32 user32 = User32.INSTANCE;
+        // Restore if minimized, otherwise just show/activate
+        user32.ShowWindow(hwnd, WinUser.SW_RESTORE);
+        user32.SetForegroundWindow(hwnd);
+    }
+}

--- a/src/main/java/com/github/arthurdeka/cedromoderndock/view/WindowPreviewPopup.java
+++ b/src/main/java/com/github/arthurdeka/cedromoderndock/view/WindowPreviewPopup.java
@@ -1,0 +1,56 @@
+package com.github.arthurdeka.cedromoderndock.view;
+
+import com.github.arthurdeka.cedromoderndock.util.NativeWindowUtils;
+import com.github.arthurdeka.cedromoderndock.util.NativeWindowUtils.WindowInfo;
+import javafx.geometry.Pos;
+import javafx.scene.control.Label;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+import javafx.stage.Popup;
+
+import java.util.List;
+
+public class WindowPreviewPopup extends Popup {
+
+    public WindowPreviewPopup(List<WindowInfo> windows, Image appIcon) {
+        VBox content = new VBox();
+        content.getStyleClass().add("window-list-popup");
+        content.setSpacing(5);
+        content.setMinWidth(200);
+
+        // Load CSS
+        content.getStylesheets().add(getClass().getResource("/com/github/arthurdeka/cedromoderndock/css/dock.css").toExternalForm());
+
+        for (WindowInfo info : windows) {
+            HBox item = new HBox();
+            item.getStyleClass().add("window-list-item");
+            item.setAlignment(Pos.CENTER_LEFT);
+            item.setSpacing(10);
+            item.setPrefWidth(200);
+
+            ImageView iconView = new ImageView(appIcon);
+            iconView.setFitWidth(24);
+            iconView.setFitHeight(24);
+            iconView.setPreserveRatio(true);
+
+            Label titleLabel = new Label(info.title());
+            titleLabel.getStyleClass().add("window-list-label");
+            titleLabel.setMaxWidth(160); // limit width to avoid huge popups
+            titleLabel.setWrapText(false);
+
+            item.getChildren().addAll(iconView, titleLabel);
+
+            item.setOnMouseClicked(e -> {
+                NativeWindowUtils.activateWindow(info.hwnd());
+                this.hide();
+            });
+
+            content.getChildren().add(item);
+        }
+
+        this.getContent().add(content);
+        this.setAutoHide(true);
+    }
+}

--- a/src/main/java/com/github/arthurdeka/cedromoderndock/view/WindowPreviewPopup.java
+++ b/src/main/java/com/github/arthurdeka/cedromoderndock/view/WindowPreviewPopup.java
@@ -51,6 +51,7 @@ public class WindowPreviewPopup extends Popup {
         }
 
         this.getContent().add(content);
-        this.setAutoHide(true);
+        // Do not auto-hide on focus loss, we manage visibility manually
+        this.setAutoHide(false);
     }
 }

--- a/src/main/resources/com/github/arthurdeka/cedromoderndock/css/dock.css
+++ b/src/main/resources/com/github/arthurdeka/cedromoderndock/css/dock.css
@@ -21,12 +21,6 @@
 
 }
 
-.dock-button:hover {
-    -fx-scale-x: 1.3;
-    -fx-scale-y: 1.3;
-
-}
-
 /* Window Preview Popup */
 .window-list-popup {
     -fx-background-color: rgba(30, 30, 30, 0.9);

--- a/src/main/resources/com/github/arthurdeka/cedromoderndock/css/dock.css
+++ b/src/main/resources/com/github/arthurdeka/cedromoderndock/css/dock.css
@@ -27,3 +27,31 @@
 
 }
 
+/* Window Preview Popup */
+.window-list-popup {
+    -fx-background-color: rgba(30, 30, 30, 0.9);
+    -fx-background-radius: 10;
+    -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.6), 10, 0, 0, 0);
+    -fx-padding: 8;
+    -fx-border-color: rgba(255, 255, 255, 0.1);
+    -fx-border-radius: 10;
+    -fx-border-width: 1;
+}
+
+.window-list-item {
+    -fx-padding: 5 10 5 10;
+    -fx-background-radius: 6;
+    -fx-cursor: hand;
+    -fx-alignment: center-left;
+    -fx-spacing: 10;
+}
+
+.window-list-item:hover {
+    -fx-background-color: rgba(255, 255, 255, 0.15);
+}
+
+.window-list-label {
+    -fx-text-fill: white;
+    -fx-font-family: "Segoe UI", sans-serif;
+    -fx-font-size: 12px;
+}


### PR DESCRIPTION
This PR implements a feature where hovering over a dock app icon displays a preview list of that application's open windows (title and icon), similar to the native Windows taskbar. It utilizes JNA for window enumeration and activation, and a custom JavaFX Popup for the UI. It handles multiple windows per application and ensures proper activation when a window is clicked.

---
*PR created automatically by Jules for task [7170141887462297483](https://jules.google.com/task/7170141887462297483) started by @arthurdeka*