### PR TITLE
feat: windows list shows up when hovering software icon

### DIFF
--- a/src/main/java/com/github/arthurdeka/cedromoderndock/controller/DockController.java
+++ b/src/main/java/com/github/arthurdeka/cedromoderndock/controller/DockController.java
@@ -51,7 +51,8 @@ public class DockController {
         model = SaveAndLoadDockSettings.load();
 
         windowPreviewPopup = new WindowPreviewPopup();
-        hideTimer = new PauseTransition(Duration.millis(300));
+        // Increased delay to allow moving mouse from dock icon to popup
+        hideTimer = new PauseTransition(Duration.millis(500));
         hideTimer.setOnFinished(e -> windowPreviewPopup.hide());
 
         enableDrag();

--- a/src/main/java/com/github/arthurdeka/cedromoderndock/controller/DockController.java
+++ b/src/main/java/com/github/arthurdeka/cedromoderndock/controller/DockController.java
@@ -41,6 +41,7 @@ public class DockController {
     private Stage stage;
     private WindowPreviewPopup windowPreviewPopup;
     private PauseTransition hideTimer;
+    private boolean isHoveringPopup = false;
 
     // variables for the enableDrag function
     private double xOffset = 0;
@@ -53,7 +54,11 @@ public class DockController {
         windowPreviewPopup = new WindowPreviewPopup();
         // Increased delay to allow moving mouse from dock icon to popup
         hideTimer = new PauseTransition(Duration.millis(500));
-        hideTimer.setOnFinished(e -> windowPreviewPopup.hide());
+        hideTimer.setOnFinished(e -> {
+            if (!isHoveringPopup) {
+                windowPreviewPopup.hide();
+            }
+        });
 
         enableDrag();
         updateDockUI();
@@ -202,8 +207,14 @@ public class DockController {
                 windowPreviewPopup.showAbove(button);
 
                 // Also handle mouse over popup to prevent hiding
-                windowPreviewPopup.getContainer().setOnMouseEntered(ev -> hideTimer.stop());
-                windowPreviewPopup.getContainer().setOnMouseExited(ev -> hideTimer.playFromStart());
+                windowPreviewPopup.getContainer().setOnMouseEntered(ev -> {
+                    isHoveringPopup = true;
+                    hideTimer.stop();
+                });
+                windowPreviewPopup.getContainer().setOnMouseExited(ev -> {
+                    isHoveringPopup = false;
+                    hideTimer.playFromStart();
+                });
             }
         });
 

--- a/src/main/java/com/github/arthurdeka/cedromoderndock/controller/DockController.java
+++ b/src/main/java/com/github/arthurdeka/cedromoderndock/controller/DockController.java
@@ -227,7 +227,7 @@ public class DockController {
             }
             if (!windows.isEmpty()) {
                 windowPreviewPopup.updateContent(windows, icon, model);
-                windowPreviewPopup.showAbove(button);
+                windowPreviewPopup.showAbove(button, hBoxContainer);
                 popupOwnerButton = button;
 
             } else if (windowPreviewPopup.isShowing() && popupOwnerButton == button) {

--- a/src/main/java/com/github/arthurdeka/cedromoderndock/controller/DockController.java
+++ b/src/main/java/com/github/arthurdeka/cedromoderndock/controller/DockController.java
@@ -42,6 +42,7 @@ public class DockController {
     private WindowPreviewPopup windowPreviewPopup;
     private PauseTransition hideTimer;
     private boolean isHoveringPopup = false;
+    private Button currentHoverButton;
 
     // variables for the enableDrag function
     private double xOffset = 0;
@@ -181,12 +182,19 @@ public class DockController {
         PauseTransition showDelay = new PauseTransition(Duration.millis(300));
 
         button.setOnMouseEntered(e -> {
+            currentHoverButton = button;
             hideTimer.stop();
+            if (windowPreviewPopup.isShowing()) {
+                windowPreviewPopup.hide();
+            }
             showDelay.setOnFinished(ev -> showWindowPreview(button, item, icon));
             showDelay.playFromStart();
         });
 
         button.setOnMouseExited(e -> {
+            if (currentHoverButton == button) {
+                currentHoverButton = null;
+            }
             showDelay.stop();
             hideTimer.playFromStart();
         });
@@ -202,6 +210,9 @@ public class DockController {
 
         task.setOnSucceeded(e -> {
             List<NativeWindowUtils.WindowInfo> windows = task.getValue();
+            if (currentHoverButton != button || !button.isHover()) {
+                return;
+            }
             if (!windows.isEmpty()) {
                 windowPreviewPopup.updateContent(windows, icon, model);
                 windowPreviewPopup.showAbove(button);
@@ -215,6 +226,8 @@ public class DockController {
                     isHoveringPopup = false;
                     hideTimer.playFromStart();
                 });
+            } else if (windowPreviewPopup.isShowing()) {
+                windowPreviewPopup.hide();
             }
         });
 

--- a/src/main/java/com/github/arthurdeka/cedromoderndock/util/NativeWindowUtils.java
+++ b/src/main/java/com/github/arthurdeka/cedromoderndock/util/NativeWindowUtils.java
@@ -1,0 +1,88 @@
+package com.github.arthurdeka.cedromoderndock.util;
+
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.platform.win32.Kernel32;
+import com.sun.jna.platform.win32.User32;
+import com.sun.jna.platform.win32.WinDef.HWND;
+import com.sun.jna.platform.win32.WinNT;
+import com.sun.jna.ptr.IntByReference;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+public class NativeWindowUtils {
+
+    public record WindowInfo(HWND hwnd, String title) {}
+
+    public static List<WindowInfo> getOpenWindows(String executablePath) {
+        List<WindowInfo> windows = new ArrayList<>();
+        if (executablePath == null || executablePath.isEmpty()) {
+            return windows;
+        }
+
+        final Path targetPath = Paths.get(executablePath).toAbsolutePath();
+
+        User32.INSTANCE.EnumWindows((hWnd, arg1) -> {
+            if (User32.INSTANCE.IsWindowVisible(hWnd)) {
+                char[] buffer = new char[1024];
+                User32.INSTANCE.GetWindowText(hWnd, buffer, 1024);
+                String title = new String(buffer).trim();
+
+                // Skip windows without title or hidden ones (sometimes invisible windows report visible via IsWindowVisible but have empty title/rect)
+                if (title.isEmpty()) {
+                    return true;
+                }
+
+                // Check if it's the correct process
+                if (isWindowFromExecutable(hWnd, targetPath)) {
+                    windows.add(new WindowInfo(hWnd, title));
+                }
+            }
+            return true;
+        }, null);
+
+        return windows;
+    }
+
+    private static boolean isWindowFromExecutable(HWND hWnd, Path targetPath) {
+        IntByReference pidRef = new IntByReference();
+        User32.INSTANCE.GetWindowThreadProcessId(hWnd, pidRef);
+        int pid = pidRef.getValue();
+
+        WinNT.HANDLE process = Kernel32.INSTANCE.OpenProcess(
+                Kernel32.PROCESS_QUERY_INFORMATION | Kernel32.PROCESS_VM_READ,
+                false,
+                pid
+        );
+
+        if (process != null) {
+            try {
+                char[] pathBuffer = new char[1024];
+                IntByReference size = new IntByReference(pathBuffer.length);
+                if (Kernel32.INSTANCE.QueryFullProcessImageName(process, 0, pathBuffer, size)) {
+                    String processPathStr = new String(pathBuffer, 0, size.getValue());
+                    Path processPath = Paths.get(processPathStr).toAbsolutePath();
+                    if (processPath.equals(targetPath)) {
+                        return true;
+                    }
+                }
+            } finally {
+                Kernel32.INSTANCE.CloseHandle(process);
+            }
+        }
+        return false;
+    }
+
+    public static void activateWindow(HWND hwnd) {
+        if (hwnd == null) return;
+
+        // Restore window if minimized
+        User32.INSTANCE.ShowWindow(hwnd, User32.SW_RESTORE);
+
+        // Bring to front
+        User32.INSTANCE.SetForegroundWindow(hwnd);
+    }
+}

--- a/src/main/java/com/github/arthurdeka/cedromoderndock/view/WindowPreviewPopup.java
+++ b/src/main/java/com/github/arthurdeka/cedromoderndock/view/WindowPreviewPopup.java
@@ -139,6 +139,7 @@ public class WindowPreviewPopup extends Popup {
         double h = getHeight();
 
         setX(bounds.getMinX() + (bounds.getWidth() / 2) - (w / 2));
-        setY(bounds.getMinY() - h - 10);
+        // Position immediately above the button with a smaller gap to allow easier mouse traversal
+        setY(bounds.getMinY() - h - 5);
     }
 }

--- a/src/main/java/com/github/arthurdeka/cedromoderndock/view/WindowPreviewPopup.java
+++ b/src/main/java/com/github/arthurdeka/cedromoderndock/view/WindowPreviewPopup.java
@@ -24,6 +24,7 @@ public class WindowPreviewPopup extends Popup {
 
     private final VBox container;
     private Node currentTarget;
+    private Node currentDock;
     private final ChangeListener<Number> sizeListener = (obs, old, val) -> reposition();
 
     public WindowPreviewPopup() {
@@ -122,8 +123,9 @@ public class WindowPreviewPopup extends Popup {
         return container;
     }
 
-    public void showAbove(Node target) {
+    public void showAbove(Node target, Node dockContainer) {
         this.currentTarget = target;
+        this.currentDock = dockContainer;
         Bounds bounds = target.localToScreen(target.getBoundsInLocal());
 
         if (!isShowing()) {
@@ -139,13 +141,14 @@ public class WindowPreviewPopup extends Popup {
 
         double w = getWidth();
         double h = getHeight();
-        double gap = 8;
+        double gap = 5;
 
         setX(bounds.getMinX() + (bounds.getWidth() / 2) - (w / 2));
 
         Rectangle2D screenBounds = getScreenBounds(bounds);
-        double yAbove = bounds.getMinY() - h - gap;
-        double yBelow = bounds.getMaxY() + gap;
+        Bounds dockBounds = getDockBounds(bounds);
+        double yAbove = dockBounds.getMinY() - h - gap;
+        double yBelow = dockBounds.getMaxY() + gap;
 
         if (yAbove < screenBounds.getMinY() + gap) {
             setY(yBelow);
@@ -164,5 +167,13 @@ public class WindowPreviewPopup extends Popup {
             return screen.getVisualBounds();
         }
         return Screen.getPrimary().getVisualBounds();
+    }
+
+    private Bounds getDockBounds(Bounds fallbackBounds) {
+        if (currentDock == null) {
+            return fallbackBounds;
+        }
+        Bounds dockBounds = currentDock.localToScreen(currentDock.getBoundsInLocal());
+        return dockBounds != null ? dockBounds : fallbackBounds;
     }
 }

--- a/src/main/java/com/github/arthurdeka/cedromoderndock/view/WindowPreviewPopup.java
+++ b/src/main/java/com/github/arthurdeka/cedromoderndock/view/WindowPreviewPopup.java
@@ -1,0 +1,144 @@
+package com.github.arthurdeka.cedromoderndock.view;
+
+import com.github.arthurdeka.cedromoderndock.model.DockModel;
+import com.github.arthurdeka.cedromoderndock.util.NativeWindowUtils;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+import javafx.geometry.Bounds;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Label;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
+import javafx.stage.Popup;
+
+import java.util.List;
+
+public class WindowPreviewPopup extends Popup {
+
+    private final VBox container;
+    private Node currentTarget;
+    private final ChangeListener<Number> sizeListener = (obs, old, val) -> reposition();
+
+    public WindowPreviewPopup() {
+        this.container = new VBox();
+        this.container.setPadding(new Insets(10));
+        this.container.setSpacing(5);
+        this.container.setAlignment(Pos.CENTER_LEFT);
+
+        // Prevent auto-hide when clicking inside the popup
+        this.setAutoHide(false);
+        this.getContent().add(container);
+
+        widthProperty().addListener(sizeListener);
+        heightProperty().addListener(sizeListener);
+    }
+
+    public void updateContent(List<NativeWindowUtils.WindowInfo> windows, Image appIcon, DockModel model) {
+        container.getChildren().clear();
+
+        // Apply style from model
+        String style = String.format(
+            "-fx-background-color: rgba(%s %s); -fx-background-radius: %s;",
+            model.getDockColorRGB(),
+            model.getDockTransparency(),
+            model.getDockBorderRounding()
+        );
+        container.setStyle(style);
+
+        Color textColor = getTextColorForBackground(model.getDockColorRGB());
+
+        for (NativeWindowUtils.WindowInfo window : windows) {
+            HBox item = createWindowItem(window, appIcon, textColor);
+            container.getChildren().add(item);
+        }
+    }
+
+    private Color getTextColorForBackground(String dockColorRGB) {
+        try {
+            // Remove commas and trim
+            String cleanRGB = dockColorRGB.replace(",", " ").trim();
+            String[] parts = cleanRGB.split("\\s+");
+            if (parts.length >= 3) {
+                int r = Integer.parseInt(parts[0]);
+                int g = Integer.parseInt(parts[1]);
+                int b = Integer.parseInt(parts[2]);
+                // Calculate brightness
+                double brightness = (r * 0.299 + g * 0.587 + b * 0.114);
+                return brightness > 128 ? Color.BLACK : Color.WHITE;
+            }
+        } catch (NumberFormatException e) {
+            // Ignore, default to white
+        }
+        return Color.WHITE;
+    }
+
+    private HBox createWindowItem(NativeWindowUtils.WindowInfo window, Image appIcon, Color textColor) {
+        HBox item = new HBox();
+        item.setSpacing(10);
+        item.setPadding(new Insets(5, 10, 5, 10));
+        item.setAlignment(Pos.CENTER_LEFT);
+        item.setStyle("-fx-background-color: transparent; -fx-background-radius: 5; -fx-cursor: hand;");
+
+        // Icon
+        ImageView iconView = new ImageView(appIcon);
+        iconView.setFitWidth(16);
+        iconView.setFitHeight(16);
+        iconView.setPreserveRatio(true);
+
+        // Title
+        Label titleLabel = new Label(window.title());
+        titleLabel.setTextFill(textColor);
+        titleLabel.setStyle("-fx-font-size: 12px;");
+
+        item.getChildren().addAll(iconView, titleLabel);
+
+        // Hover effect
+        item.setOnMouseEntered(e -> {
+            item.setStyle("-fx-background-color: rgba(255, 255, 255, 0.2); -fx-background-radius: 5; -fx-cursor: hand;");
+            titleLabel.setTextFill(Color.WHITE); // Always white on hover for better contrast against hover bg
+        });
+        item.setOnMouseExited(e -> {
+            item.setStyle("-fx-background-color: transparent; -fx-background-radius: 5; -fx-cursor: hand;");
+            titleLabel.setTextFill(textColor);
+        });
+
+        // Click action
+        item.setOnMouseClicked(e -> {
+            NativeWindowUtils.activateWindow(window.hwnd());
+            this.hide();
+        });
+
+        return item;
+    }
+
+    public VBox getContainer() {
+        return container;
+    }
+
+    public void showAbove(Node target) {
+        this.currentTarget = target;
+        Bounds bounds = target.localToScreen(target.getBoundsInLocal());
+
+        if (!isShowing()) {
+            this.show(target, bounds.getMinX(), bounds.getMinY());
+        }
+        reposition();
+    }
+
+    private void reposition() {
+        if (currentTarget == null || !isShowing()) return;
+        Bounds bounds = currentTarget.localToScreen(currentTarget.getBoundsInLocal());
+        if (bounds == null) return;
+
+        double w = getWidth();
+        double h = getHeight();
+
+        setX(bounds.getMinX() + (bounds.getWidth() / 2) - (w / 2));
+        setY(bounds.getMinY() - h - 10);
+    }
+}

--- a/src/main/java/com/github/arthurdeka/cedromoderndock/view/WindowPreviewPopup.java
+++ b/src/main/java/com/github/arthurdeka/cedromoderndock/view/WindowPreviewPopup.java
@@ -7,6 +7,7 @@ import javafx.beans.value.ObservableValue;
 import javafx.geometry.Bounds;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.geometry.Rectangle2D;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.image.Image;
@@ -15,6 +16,7 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.stage.Popup;
+import javafx.stage.Screen;
 
 import java.util.List;
 
@@ -137,9 +139,25 @@ public class WindowPreviewPopup extends Popup {
 
         double w = getWidth();
         double h = getHeight();
+        double gap = 8;
 
         setX(bounds.getMinX() + (bounds.getWidth() / 2) - (w / 2));
-        // Position immediately above the button with a smaller gap to allow easier mouse traversal
-        setY(bounds.getMinY() - h - 5);
+
+        Rectangle2D screenBounds = getScreenBounds(bounds);
+        double yAbove = bounds.getMinY() - h - gap;
+        double yBelow = bounds.getMaxY() + gap;
+
+        if (yAbove < screenBounds.getMinY() + gap) {
+            setY(yBelow);
+        } else {
+            setY(yAbove);
+        }
+    }
+
+    private Rectangle2D getScreenBounds(Bounds bounds) {
+        for (Screen screen : Screen.getScreensForRectangle(bounds)) {
+            return screen.getVisualBounds();
+        }
+        return Screen.getPrimary().getVisualBounds();
     }
 }

--- a/src/main/java/com/github/arthurdeka/cedromoderndock/view/WindowPreviewPopup.java
+++ b/src/main/java/com/github/arthurdeka/cedromoderndock/view/WindowPreviewPopup.java
@@ -155,7 +155,12 @@ public class WindowPreviewPopup extends Popup {
     }
 
     private Rectangle2D getScreenBounds(Bounds bounds) {
-        for (Screen screen : Screen.getScreensForRectangle(bounds)) {
+        for (Screen screen : Screen.getScreensForRectangle(
+                bounds.getMinX(),
+                bounds.getMinY(),
+                bounds.getWidth(),
+                bounds.getHeight()
+        )) {
             return screen.getVisualBounds();
         }
         return Screen.getPrimary().getVisualBounds();


### PR DESCRIPTION
Implemented a Windows Taskbar-like feature where hovering over an application icon in the dock displays a popup list of open windows for that application.
- Added `NativeWindowUtils` using JNA (jna-platform) to enumerate visible windows, match them to the dock item's executable path, and activate them on click.
- Created `WindowPreviewPopup` (JavaFX Popup) to render the list of windows with the application icon and window title.
- Updated `DockController` to manage the popup's lifecycle, including hover delays (300ms) to prevent accidental triggers or hiding.
- Implemented dynamic styling for the popup to match the dock's user-configured color and transparency, with automatic text color adjustment (black/white) for readability.
- Cleaned up CSS string generation to handle comma-separated RGB values correctly.

---
*PR created automatically by Jules for task [3979412171503072351](https://jules.google.com/task/3979412171503072351) started by @arthurdeka*